### PR TITLE
Relax version constraints of dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ setup(
         'pandas>=1.4.0',
         'requests>=2.28.1',
         'tables>=3.7.0',
-        'tqdm~=4.64.1',
-        'pydantic~=1.10.7'
+        'tqdm>=4.64.1',
+        'pydantic>=1.10.7'
         ],
     extras_require={
         'optional': ['astropy>=4.3.1', 'dustmaps>=1.0.10', 'astroquery~=0.4', 'matplotlib~=3.6.2']

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         'pydantic>=1.10.7'
         ],
     extras_require={
-        'optional': ['astropy>=4.3.1', 'dustmaps>=1.0.10', 'astroquery~=0.4', 'matplotlib~=3.6.2']
+        'optional': ['astropy>=4.3.1', 'dustmaps>=1.0.10', 'astroquery>=0.4', 'matplotlib>=3.6.2']
         },
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown'


### PR DESCRIPTION
Fixes #87 - reduces the strength of version requirements (changing fixed versions with `~=` to broader `>=` requirements) to allow easier install into environments with other packages. In practice, the packages previously pinned with `~=` (like tqdm and matplotlib) rarely/never have breaking changes, so this should not cause issues in the future as those packages get updates.